### PR TITLE
feat: Phase 2 実装 - OBS不要の画面キャプチャ配信

### DIFF
--- a/src/main/services/binary.ts
+++ b/src/main/services/binary.ts
@@ -153,6 +153,10 @@ logDestinations: [stdout]
 rtmp: yes
 rtmpAddress: :1935
 
+# WebRTC/WHIP入力設定
+webrtc: yes
+webrtcAddress: :8889
+
 # HLS出力設定
 hls: yes
 hlsAddress: :8888
@@ -167,7 +171,6 @@ api: no
 metrics: no
 pprof: no
 rtsp: no
-webrtc: no
 srt: no
 
 # パス設定（任意のパスを受け入れる）

--- a/src/main/services/capture.ts
+++ b/src/main/services/capture.ts
@@ -1,0 +1,61 @@
+import { desktopCapturer } from 'electron'
+import { CaptureSource, CaptureInfo } from '../../shared/types'
+
+// キャプチャ状態
+let captureInfo: CaptureInfo = {
+  status: 'idle',
+  sourceId: null,
+  sourceName: null,
+  error: null
+}
+
+// キャプチャソース一覧を取得
+export async function getCaptureSources(): Promise<CaptureSource[]> {
+  const sources = await desktopCapturer.getSources({
+    types: ['screen', 'window'],
+    thumbnailSize: { width: 320, height: 180 },
+    fetchWindowIcons: true
+  })
+
+  return sources.map((source) => ({
+    id: source.id,
+    name: source.name,
+    thumbnail: source.thumbnail.toDataURL(),
+    type: source.id.startsWith('screen:') ? 'screen' : 'window'
+  }))
+}
+
+// キャプチャ開始（状態管理のみ、実際のキャプチャはレンダラーで行う）
+export function startCaptureSession(sourceId: string, sourceName: string): CaptureInfo {
+  captureInfo = {
+    status: 'capturing',
+    sourceId,
+    sourceName,
+    error: null
+  }
+  return captureInfo
+}
+
+// キャプチャ停止
+export function stopCaptureSession(): void {
+  captureInfo = {
+    status: 'idle',
+    sourceId: null,
+    sourceName: null,
+    error: null
+  }
+}
+
+// キャプチャエラー設定
+export function setCaptureError(error: string): void {
+  captureInfo = {
+    ...captureInfo,
+    status: 'error',
+    error
+  }
+}
+
+// キャプチャ状態取得
+export function getCaptureStatus(): CaptureInfo {
+  return captureInfo
+}

--- a/src/renderer/src/components/CaptureSourceSelector.tsx
+++ b/src/renderer/src/components/CaptureSourceSelector.tsx
@@ -1,0 +1,231 @@
+import { useEffect } from 'react'
+import { CaptureSource } from '../../../shared/types'
+
+interface Props {
+  sources: CaptureSource[]
+  selectedSourceId: string | null
+  isLoading: boolean
+  isCapturing: boolean
+  connectionState: RTCPeerConnectionState | null
+  onRefresh: () => void
+  onSelect: (sourceId: string) => void
+  onStartCapture: () => void
+  onStopCapture: () => void
+}
+
+export function CaptureSourceSelector({
+  sources,
+  selectedSourceId,
+  isLoading,
+  isCapturing,
+  connectionState,
+  onRefresh,
+  onSelect,
+  onStartCapture,
+  onStopCapture
+}: Props) {
+  // 初回マウント時にソース一覧を取得
+  useEffect(() => {
+    onRefresh()
+  }, [])
+
+  const getConnectionStateText = () => {
+    if (!connectionState) return null
+    switch (connectionState) {
+      case 'connecting':
+        return '接続中...'
+      case 'connected':
+        return '配信中'
+      case 'disconnected':
+        return '切断'
+      case 'failed':
+        return '接続失敗'
+      default:
+        return connectionState
+    }
+  }
+
+  const connectionStateText = getConnectionStateText()
+
+  return (
+    <div style={styles.container}>
+      <div style={styles.header}>
+        <h3 style={styles.title}>キャプチャソース</h3>
+        <button
+          style={styles.refreshButton}
+          onClick={onRefresh}
+          disabled={isLoading || isCapturing}
+        >
+          更新
+        </button>
+      </div>
+
+      {isCapturing && connectionStateText && (
+        <div style={styles.statusBar}>
+          <span
+            style={{
+              ...styles.statusDot,
+              backgroundColor: connectionState === 'connected' ? '#4caf50' : '#ff9800'
+            }}
+          />
+          {connectionStateText}
+        </div>
+      )}
+
+      <div style={styles.sourceList}>
+        {sources.length === 0 ? (
+          <p style={styles.emptyText}>
+            {isLoading ? '読み込み中...' : 'キャプチャソースが見つかりません'}
+          </p>
+        ) : (
+          sources.map((source) => (
+            <div
+              key={source.id}
+              style={{
+                ...styles.sourceItem,
+                borderColor: source.id === selectedSourceId ? '#2196f3' : '#ddd',
+                opacity: isCapturing && source.id !== selectedSourceId ? 0.5 : 1
+              }}
+              onClick={() => !isCapturing && onSelect(source.id)}
+            >
+              <img
+                src={source.thumbnail}
+                alt={source.name}
+                style={styles.thumbnail}
+              />
+              <div style={styles.sourceInfo}>
+                <span style={styles.sourceName}>{source.name}</span>
+                <span style={styles.sourceType}>
+                  {source.type === 'screen' ? '画面' : 'ウィンドウ'}
+                </span>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+
+      <div style={styles.controls}>
+        {isCapturing ? (
+          <button
+            style={{ ...styles.button, backgroundColor: '#f44336' }}
+            onClick={onStopCapture}
+            disabled={isLoading}
+          >
+            {isLoading ? '停止中...' : 'キャプチャ停止'}
+          </button>
+        ) : (
+          <button
+            style={{
+              ...styles.button,
+              backgroundColor: '#4caf50',
+              opacity: !selectedSourceId || isLoading ? 0.6 : 1
+            }}
+            onClick={onStartCapture}
+            disabled={!selectedSourceId || isLoading}
+          >
+            {isLoading ? '開始中...' : 'キャプチャ開始'}
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+const styles: { [key: string]: React.CSSProperties } = {
+  container: {
+    marginBottom: '20px'
+  },
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: '12px'
+  },
+  title: {
+    margin: 0,
+    fontSize: '16px',
+    color: '#333'
+  },
+  refreshButton: {
+    padding: '6px 12px',
+    fontSize: '12px',
+    backgroundColor: '#fff',
+    border: '1px solid #ddd',
+    borderRadius: '4px',
+    cursor: 'pointer'
+  },
+  statusBar: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    padding: '8px 12px',
+    backgroundColor: '#f5f5f5',
+    borderRadius: '4px',
+    marginBottom: '12px',
+    fontSize: '13px',
+    color: '#666'
+  },
+  statusDot: {
+    width: '8px',
+    height: '8px',
+    borderRadius: '50%'
+  },
+  sourceList: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fill, minmax(150px, 1fr))',
+    gap: '12px',
+    maxHeight: '300px',
+    overflowY: 'auto',
+    marginBottom: '16px'
+  },
+  sourceItem: {
+    padding: '8px',
+    border: '2px solid #ddd',
+    borderRadius: '8px',
+    cursor: 'pointer',
+    transition: 'border-color 0.2s, opacity 0.2s'
+  },
+  thumbnail: {
+    width: '100%',
+    aspectRatio: '16/9',
+    objectFit: 'cover',
+    borderRadius: '4px',
+    marginBottom: '8px'
+  },
+  sourceInfo: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '2px'
+  },
+  sourceName: {
+    fontSize: '12px',
+    color: '#333',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis'
+  },
+  sourceType: {
+    fontSize: '10px',
+    color: '#999'
+  },
+  emptyText: {
+    textAlign: 'center',
+    color: '#666',
+    fontSize: '13px',
+    gridColumn: '1 / -1'
+  },
+  controls: {
+    display: 'flex',
+    justifyContent: 'center'
+  },
+  button: {
+    padding: '12px 32px',
+    fontSize: '16px',
+    fontWeight: 'bold',
+    color: 'white',
+    border: 'none',
+    borderRadius: '8px',
+    cursor: 'pointer',
+    transition: 'opacity 0.2s'
+  }
+}

--- a/src/renderer/src/hooks/useCapture.ts
+++ b/src/renderer/src/hooks/useCapture.ts
@@ -1,0 +1,158 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { CaptureSource, CaptureInfo } from '../../../shared/types'
+import { WHIPClient } from '../lib/whip'
+
+interface UseCaptureResult {
+  sources: CaptureSource[]
+  captureInfo: CaptureInfo
+  isCapturing: boolean
+  isLoading: boolean
+  error: string | null
+  connectionState: RTCPeerConnectionState | null
+  refreshSources: () => Promise<void>
+  startCapture: (sourceId: string) => Promise<void>
+  stopCapture: () => Promise<void>
+}
+
+export function useCapture(): UseCaptureResult {
+  const [sources, setSources] = useState<CaptureSource[]>([])
+  const [captureInfo, setCaptureInfo] = useState<CaptureInfo>({
+    status: 'idle',
+    sourceId: null,
+    sourceName: null,
+    error: null
+  })
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [connectionState, setConnectionState] = useState<RTCPeerConnectionState | null>(null)
+
+  const whipClientRef = useRef<WHIPClient | null>(null)
+  const mediaStreamRef = useRef<MediaStream | null>(null)
+
+  // キャプチャ状態の監視
+  useEffect(() => {
+    const unsubscribe = window.electronAPI.onCaptureStatus((info) => {
+      setCaptureInfo(info)
+    })
+    return unsubscribe
+  }, [])
+
+  // 初期状態を取得
+  useEffect(() => {
+    window.electronAPI.getCaptureStatus().then(setCaptureInfo)
+  }, [])
+
+  // キャプチャソース一覧を更新
+  const refreshSources = useCallback(async () => {
+    try {
+      setIsLoading(true)
+      setError(null)
+      const sources = await window.electronAPI.getCaptureSources()
+      setSources(sources)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'ソース取得に失敗しました')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  // キャプチャ開始
+  const startCapture = useCallback(async (sourceId: string) => {
+    try {
+      setIsLoading(true)
+      setError(null)
+
+      // メインプロセスにキャプチャ開始を通知
+      await window.electronAPI.startCapture(sourceId)
+
+      // MediaStreamを取得
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: false,
+        video: {
+          mandatory: {
+            chromeMediaSource: 'desktop',
+            chromeMediaSourceId: sourceId,
+            maxWidth: 1920,
+            maxHeight: 1080,
+            maxFrameRate: 30
+          }
+        } as MediaTrackConstraints
+      })
+
+      mediaStreamRef.current = stream
+
+      // WHIPクライアントで送信
+      const whipClient = new WHIPClient({
+        onConnectionStateChange: (state) => {
+          setConnectionState(state)
+          if (state === 'failed' || state === 'disconnected') {
+            setError('WebRTC接続が切断されました')
+          }
+        },
+        onError: (err) => {
+          setError(err.message)
+        }
+      })
+
+      whipClientRef.current = whipClient
+      await whipClient.publish(stream)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'キャプチャ開始に失敗しました')
+      await stopCapture()
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  // キャプチャ停止
+  const stopCapture = useCallback(async () => {
+    try {
+      setIsLoading(true)
+
+      // WHIPクライアントを停止
+      if (whipClientRef.current) {
+        await whipClientRef.current.stop()
+        whipClientRef.current = null
+      }
+
+      // MediaStreamを停止
+      if (mediaStreamRef.current) {
+        mediaStreamRef.current.getTracks().forEach((track) => track.stop())
+        mediaStreamRef.current = null
+      }
+
+      // メインプロセスに通知
+      await window.electronAPI.stopCapture()
+      setConnectionState(null)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'キャプチャ停止に失敗しました')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  // コンポーネントアンマウント時のクリーンアップ
+  useEffect(() => {
+    return () => {
+      if (whipClientRef.current) {
+        whipClientRef.current.stop()
+      }
+      if (mediaStreamRef.current) {
+        mediaStreamRef.current.getTracks().forEach((track) => track.stop())
+      }
+    }
+  }, [])
+
+  return {
+    sources,
+    captureInfo,
+    isCapturing: captureInfo.status === 'capturing',
+    isLoading,
+    error,
+    connectionState,
+    refreshSources,
+    startCapture,
+    stopCapture
+  }
+}

--- a/src/renderer/src/lib/whip.ts
+++ b/src/renderer/src/lib/whip.ts
@@ -1,0 +1,158 @@
+// WHIP (WebRTC-HTTP Ingestion Protocol) クライアント
+
+const WHIP_ENDPOINT = 'http://localhost:8889/live/whip'
+
+export interface WHIPClientOptions {
+  onConnectionStateChange?: (state: RTCPeerConnectionState) => void
+  onError?: (error: Error) => void
+}
+
+export class WHIPClient {
+  private pc: RTCPeerConnection | null = null
+  private resourceUrl: string | null = null
+  private options: WHIPClientOptions
+
+  constructor(options: WHIPClientOptions = {}) {
+    this.options = options
+  }
+
+  async publish(stream: MediaStream): Promise<void> {
+    // RTCPeerConnectionを作成
+    this.pc = new RTCPeerConnection({
+      iceServers: [] // ローカル接続のためICEサーバー不要
+    })
+
+    // 接続状態の監視
+    this.pc.onconnectionstatechange = () => {
+      if (this.pc) {
+        this.options.onConnectionStateChange?.(this.pc.connectionState)
+      }
+    }
+
+    // MediaStreamのトラックを追加
+    stream.getTracks().forEach((track) => {
+      this.pc!.addTrack(track, stream)
+    })
+
+    // ICE候補の収集完了を待つ
+    await this.waitForIceGathering()
+
+    // Offer SDPを作成
+    const offer = await this.pc.createOffer()
+    await this.pc.setLocalDescription(offer)
+
+    // ICE候補の収集完了を待つ
+    const localDescription = await this.waitForLocalDescription()
+
+    if (!localDescription) {
+      throw new Error('Failed to gather ICE candidates')
+    }
+
+    // WHIPエンドポイントにOfferを送信
+    const response = await fetch(WHIP_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/sdp'
+      },
+      body: localDescription.sdp
+    })
+
+    if (!response.ok) {
+      const errorText = await response.text()
+      throw new Error(`WHIP request failed: ${response.status} ${errorText}`)
+    }
+
+    // リソースURLを保存（後で削除に使用）
+    this.resourceUrl = response.headers.get('Location') || WHIP_ENDPOINT
+
+    // Answer SDPを設定
+    const answerSdp = await response.text()
+    await this.pc.setRemoteDescription({
+      type: 'answer',
+      sdp: answerSdp
+    })
+  }
+
+  private waitForIceGathering(): Promise<void> {
+    return new Promise((resolve) => {
+      if (!this.pc) {
+        resolve()
+        return
+      }
+
+      if (this.pc.iceGatheringState === 'complete') {
+        resolve()
+        return
+      }
+
+      const checkState = () => {
+        if (this.pc?.iceGatheringState === 'complete') {
+          this.pc.removeEventListener('icegatheringstatechange', checkState)
+          resolve()
+        }
+      }
+
+      this.pc.addEventListener('icegatheringstatechange', checkState)
+
+      // タイムアウト: 5秒
+      setTimeout(() => {
+        this.pc?.removeEventListener('icegatheringstatechange', checkState)
+        resolve()
+      }, 5000)
+    })
+  }
+
+  private waitForLocalDescription(): Promise<RTCSessionDescription | null> {
+    return new Promise((resolve) => {
+      if (!this.pc) {
+        resolve(null)
+        return
+      }
+
+      // 即座にローカル記述が利用可能な場合
+      if (this.pc.localDescription && this.pc.iceGatheringState === 'complete') {
+        resolve(this.pc.localDescription)
+        return
+      }
+
+      const checkState = () => {
+        if (this.pc?.iceGatheringState === 'complete' && this.pc.localDescription) {
+          this.pc.removeEventListener('icegatheringstatechange', checkState)
+          resolve(this.pc.localDescription)
+        }
+      }
+
+      this.pc.addEventListener('icegatheringstatechange', checkState)
+
+      // タイムアウト: 5秒
+      setTimeout(() => {
+        this.pc?.removeEventListener('icegatheringstatechange', checkState)
+        resolve(this.pc?.localDescription || null)
+      }, 5000)
+    })
+  }
+
+  async stop(): Promise<void> {
+    // WHIPリソースを削除
+    if (this.resourceUrl) {
+      try {
+        await fetch(this.resourceUrl, {
+          method: 'DELETE'
+        })
+      } catch {
+        // 削除エラーは無視
+      }
+      this.resourceUrl = null
+    }
+
+    // PeerConnectionを閉じる
+    if (this.pc) {
+      this.pc.close()
+      this.pc = null
+    }
+  }
+
+  isConnected(): boolean {
+    return this.pc?.connectionState === 'connected'
+  }
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,6 +1,25 @@
 // 配信状態
 export type StreamStatus = 'idle' | 'starting' | 'running' | 'stopping' | 'error'
 
+// キャプチャソース
+export interface CaptureSource {
+  id: string
+  name: string
+  thumbnail: string
+  type: 'screen' | 'window'
+}
+
+// キャプチャ状態
+export type CaptureStatus = 'idle' | 'capturing' | 'error'
+
+// キャプチャ情報
+export interface CaptureInfo {
+  status: CaptureStatus
+  sourceId: string | null
+  sourceName: string | null
+  error: string | null
+}
+
 // セットアップ状態
 export type SetupStatus = 'pending' | 'downloading' | 'ready' | 'error'
 
@@ -42,6 +61,12 @@ export const IPC_CHANNELS = {
   STREAM_STOP: 'stream:stop',
   STREAM_STATUS: 'stream:status',
 
+  // キャプチャ
+  CAPTURE_GET_SOURCES: 'capture:getSources',
+  CAPTURE_START: 'capture:start',
+  CAPTURE_STOP: 'capture:stop',
+  CAPTURE_STATUS: 'capture:status',
+
   // 設定
   CONFIG_GET: 'config:get',
   CONFIG_SET: 'config:set'
@@ -59,4 +84,11 @@ export interface ElectronAPI {
   stopStream: () => Promise<void>
   onStreamStatus: (callback: (info: StreamInfo) => void) => () => void
   getStreamStatus: () => Promise<StreamInfo>
+
+  // キャプチャ
+  getCaptureSources: () => Promise<CaptureSource[]>
+  startCapture: (sourceId: string) => Promise<CaptureInfo>
+  stopCapture: () => Promise<void>
+  onCaptureStatus: (callback: (info: CaptureInfo) => void) => () => void
+  getCaptureStatus: () => Promise<CaptureInfo>
 }


### PR DESCRIPTION
## Summary

- OBSなしでアプリ内から直接画面/ウィンドウをキャプチャして配信可能に
- desktopCapturer → WebRTC/WHIP → MediaMTX → HLS の配信フローを実装
- キャプチャソース選択UIを追加

## 変更内容

### 新規ファイル
- `src/main/services/capture.ts` - キャプチャセッション管理
- `src/renderer/src/lib/whip.ts` - WHIPクライアント
- `src/renderer/src/hooks/useCapture.ts` - キャプチャフック
- `src/renderer/src/components/CaptureSourceSelector.tsx` - ソース選択UI

### 変更ファイル
- MediaMTX設定にWebRTC/WHIP入力を追加
- 型定義にCaptureSource, CaptureInfo追加
- App.tsxにキャプチャUI統合

## Test plan

- [ ] `npm run dev` でアプリ起動
- [ ] キャプチャソース一覧が表示される
- [ ] 画面/ウィンドウを選択できる
- [ ] 「キャプチャ開始」で配信開始
- [ ] 公開URLでHLS再生確認
- [ ] macOS: 画面収録権限の確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)