### PR TITLE
feat: ストリームIDをlocalStorageに保存

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -11,6 +11,8 @@ import { CaptureSource, Platform } from '../../shared/types'
 type StreamMode = 'direct' | 'obs'
 type AppState = 'idle' | 'selecting' | 'streaming'
 
+const STORAGE_KEY = 'pebble-stream-id'
+
 function App() {
   const setup = useSetup()
   const streaming = useStreaming()
@@ -19,7 +21,9 @@ function App() {
   const [appState, setAppState] = useState<AppState>('idle')
   const [selectedSource, setSelectedSource] = useState<CaptureSource | null>(null)
   const [platform, setPlatform] = useState<Platform | null>(null)
-  const [customStreamId, setCustomStreamId] = useState<string>('')
+  const [customStreamId, setCustomStreamId] = useState<string>(() => {
+    return localStorage.getItem(STORAGE_KEY) || ''
+  })
   const [streamIdError, setStreamIdError] = useState<string | null>(null)
 
   // プラットフォーム取得
@@ -159,8 +163,14 @@ function App() {
                 type="text"
                 value={customStreamId}
                 onChange={(e) => {
-                  setCustomStreamId(e.target.value)
+                  const value = e.target.value
+                  setCustomStreamId(value)
                   setStreamIdError(null)
+                  if (value) {
+                    localStorage.setItem(STORAGE_KEY, value)
+                  } else {
+                    localStorage.removeItem(STORAGE_KEY)
+                  }
                 }}
                 placeholder="空欄でランダム生成"
                 style={{


### PR DESCRIPTION
## Summary
- 設定したストリームIDをlocalStorageに保存し、次回起動時に自動復元する機能を追加
- 入力時に即座に保存、空欄にした場合は保存データを削除

## Test plan
- [ ] アプリを起動し、ストリームIDを入力
- [ ] アプリを終了して再起動
- [ ] 入力欄に前回のストリームIDが復元されていることを確認
- [ ] 入力欄を空にして再起動し、空のままであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)