### PR TITLE
OBS配信画面と直接配信画面を分離

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useCallback, ChangeEvent } from 'react'
 import logoImage from './assets/logo.png'
 import { SetupProgress } from './components/SetupProgress'
-import { UrlDisplay } from './components/UrlDisplay'
+import { ObsStreamingScreen } from './components/ObsStreamingScreen'
+import { DirectStreamingScreen } from './components/DirectStreamingScreen'
 import { SourceSelectModal } from './components/SourceSelectModal'
 import { useSetup } from './hooks/useSetup'
 import { useStreaming } from './hooks/useStreaming'
@@ -225,81 +226,22 @@ function App() {
 
         {/* 配信中画面 */}
         {setup.isReady && appState === 'streaming' && (
-          <div style={{
-            ...styles.streamingScreen,
-            paddingTop: platform === 'win32' ? '8px' : '32px'
-          }}>
-            {/* ステータス */}
-            <div style={styles.statusCard}>
-              <div style={styles.statusHeader}>
-                <span
-                  style={{
-                    ...styles.statusDot,
-                    backgroundColor: capture.connectionState === 'connected'
-                      ? streaming.streamInfo.readyForPlayback
-                        ? '#4caf50'  // 配信中（再生可能）
-                        : '#ff9800'  // 準備中
-                      : streaming.isStreaming
-                        ? '#ff9800'  // OBS接続待ち
-                        : '#ff9800'  // 接続中
-                  }}
-                />
-                <span style={styles.statusText}>
-                  {capture.connectionState === 'connected'
-                    ? streaming.streamInfo.readyForPlayback
-                      ? '配信中'
-                      : '準備中...'
-                    : streamMode === 'obs' && streaming.isStreaming
-                      ? 'OBS接続待ち'
-                      : '接続中...'}
-                </span>
-              </div>
-
-              {/* 選択中のソース情報 */}
-              {streamMode === 'direct' && selectedSource && (
-                <div style={styles.sourcePreview}>
-                  {selectedSource.thumbnail ? (
-                    <img
-                      src={selectedSource.thumbnail}
-                      alt={selectedSource.name}
-                      style={styles.previewThumbnail}
-                    />
-                  ) : (
-                    <div style={styles.previewPlaceholder}>
-                      {selectedSource.type === 'screen' ? '🖥️' : '🪟'}
-                    </div>
-                  )}
-                  <div style={styles.previewInfo}>
-                    <span style={styles.previewName}>{selectedSource.name}</span>
-                    <span style={styles.previewType}>
-                      {selectedSource.type === 'screen' ? '画面' : 'ウィンドウ'}
-                    </span>
-                  </div>
-                </div>
-              )}
-            </div>
-
-            {/* URL表示 */}
-            <UrlDisplay streamInfo={streaming.streamInfo} mode={streamMode} />
-
-            {/* 注意書き */}
-            <div style={styles.notice}>
-              <span style={styles.noticeText}>
-                無料サーバーで運用中のため、遅延4秒以上・画質480pでの配信となります
-              </span>
-            </div>
-
-            {/* 停止/接続中ボタン */}
-            {isLoading && !capture.isCapturing && !streaming.isStreaming ? (
-              <button style={styles.connectingButton} disabled>
-                接続中...
-              </button>
-            ) : (
-              <button style={styles.stopButton} onClick={handleStop}>
-                配信停止
-              </button>
-            )}
-          </div>
+          streamMode === 'obs'
+            ? <ObsStreamingScreen
+                streamInfo={streaming.streamInfo}
+                onStop={handleStop}
+                isLoading={isLoading && !streaming.isStreaming}
+                platform={platform}
+              />
+            : <DirectStreamingScreen
+                streamInfo={streaming.streamInfo}
+                connectionState={capture.connectionState}
+                selectedSource={selectedSource}
+                onStop={handleStop}
+                isLoading={isLoading}
+                isCapturing={capture.isCapturing}
+                platform={platform}
+              />
         )}
 
         {/* エラー表示 */}
@@ -330,19 +272,12 @@ const colors = {
   // 背景
   bgPrimary: '#F7F6F3',      // 温かみのあるオフホワイト
   bgSecondary: '#EDEAE5',    // サンドベージュ
-  // 石っぽいグレー
-  stone: '#6B7280',
-  stoneDark: '#4B5563',
-  stoneLight: '#9CA3AF',
   // アクセント（温かみのある茶系）
   accent: '#8B7355',
   accentLight: '#A89076',
   // 状態色
-  success: '#5D8A66',
-  successBg: '#E8F0EA',
   error: '#C45C4A',
   errorBg: '#FAE8E5',
-  warning: '#C4956A',
   // テキスト
   textPrimary: '#3D3D3D',
   textSecondary: '#6B6B6B',
@@ -424,17 +359,6 @@ const styles: { [key: string]: React.CSSProperties } = {
     gap: '20px',
     flex: 1
   },
-  notice: {
-    padding: '10px 14px',
-    backgroundColor: colors.bgSecondary,
-    borderRadius: '10px',
-    border: `1px solid ${colors.border}`
-  },
-  noticeText: {
-    fontSize: '11px',
-    color: colors.textMuted,
-    lineHeight: 1.5
-  },
   modeSelector: {
     display: 'flex',
     flexDirection: 'column',
@@ -510,106 +434,6 @@ const styles: { [key: string]: React.CSSProperties } = {
     transition: 'all 0.2s ease',
     marginTop: 'auto'
   },
-  // 配信中画面
-  streamingScreen: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '16px',
-    paddingTop: '32px',  // タイトルバー分のスペース
-    flex: 1
-  },
-  statusCard: {
-    padding: '20px',
-    backgroundColor: colors.successBg,
-    borderRadius: '14px',
-    border: `1px solid rgba(93, 138, 102, 0.2)`
-  },
-  statusHeader: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '10px'
-  },
-  statusDot: {
-    width: '10px',
-    height: '10px',
-    borderRadius: '50%',
-    boxShadow: '0 0 8px rgba(93, 138, 102, 0.5)'
-  },
-  statusText: {
-    fontSize: '15px',
-    fontWeight: 600,
-    color: colors.success
-  },
-  sourcePreview: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '12px',
-    marginTop: '14px',
-    padding: '12px',
-    backgroundColor: 'rgba(255, 255, 255, 0.8)',
-    borderRadius: '10px',
-    border: `1px solid ${colors.border}`
-  },
-  previewThumbnail: {
-    width: '100px',
-    height: '56px',
-    objectFit: 'cover',
-    borderRadius: '6px',
-    border: `1px solid ${colors.border}`
-  },
-  previewPlaceholder: {
-    width: '100px',
-    height: '56px',
-    backgroundColor: colors.bgSecondary,
-    borderRadius: '6px',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    fontSize: '20px',
-    border: `1px solid ${colors.border}`
-  },
-  previewInfo: {
-    flex: 1,
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '4px',
-    minWidth: 0
-  },
-  previewName: {
-    fontSize: '13px',
-    color: colors.textPrimary,
-    fontWeight: 500,
-    wordBreak: 'break-word'
-  },
-  previewType: {
-    fontSize: '11px',
-    color: colors.textMuted
-  },
-  stopButton: {
-    padding: '16px 32px',
-    fontSize: '16px',
-    fontWeight: 600,
-    color: colors.white,
-    background: `linear-gradient(135deg, ${colors.error} 0%, #D4776A 100%)`,
-    border: 'none',
-    borderRadius: '14px',
-    cursor: 'pointer',
-    boxShadow: '0 4px 14px rgba(196, 92, 74, 0.35)',
-    transition: 'all 0.2s ease',
-    marginTop: 'auto'
-  },
-  connectingButton: {
-    padding: '16px 32px',
-    fontSize: '16px',
-    fontWeight: 600,
-    color: colors.white,
-    background: `linear-gradient(135deg, ${colors.stoneLight} 0%, ${colors.stone} 100%)`,
-    border: 'none',
-    borderRadius: '14px',
-    cursor: 'not-allowed',
-    marginTop: 'auto',
-    opacity: 0.7
-  },
   error: {
     color: colors.error,
     fontSize: '13px',
@@ -618,13 +442,6 @@ const styles: { [key: string]: React.CSSProperties } = {
     padding: '12px',
     backgroundColor: colors.errorBg,
     borderRadius: '10px'
-  },
-  footer: {
-    textAlign: 'center',
-    marginTop: '24px',
-    fontSize: '11px',
-    color: colors.textMuted,
-    fontWeight: 500
   }
 }
 

--- a/src/renderer/src/components/DirectStreamingScreen.tsx
+++ b/src/renderer/src/components/DirectStreamingScreen.tsx
@@ -1,0 +1,227 @@
+import type { StreamInfo, CaptureSource, Platform } from '../../../shared/types'
+import { UrlDisplay } from './UrlDisplay'
+
+interface Props {
+  streamInfo: StreamInfo
+  connectionState: RTCPeerConnectionState | null
+  selectedSource: CaptureSource | null
+  onStop: () => void
+  isLoading: boolean
+  isCapturing: boolean
+  platform: Platform | null
+}
+
+export function DirectStreamingScreen({
+  streamInfo,
+  connectionState,
+  selectedSource,
+  onStop,
+  isLoading,
+  isCapturing,
+  platform
+}: Props) {
+  const getStatusColor = (): string => {
+    if (connectionState === 'connected') {
+      return streamInfo.readyForPlayback ? '#4caf50' : '#ff9800'
+    }
+    return '#ff9800'
+  }
+
+  const getStatusText = (): string => {
+    if (connectionState === 'connected') {
+      return streamInfo.readyForPlayback ? '配信中' : '準備中...'
+    }
+    return '接続中...'
+  }
+
+  return (
+    <div style={{
+      ...styles.streamingScreen,
+      paddingTop: platform === 'win32' ? '8px' : '32px'
+    }}>
+      {/* ステータス */}
+      <div style={styles.statusCard}>
+        <div style={styles.statusHeader}>
+          <span
+            style={{
+              ...styles.statusDot,
+              backgroundColor: getStatusColor()
+            }}
+          />
+          <span style={styles.statusText}>{getStatusText()}</span>
+        </div>
+
+        {/* 選択中のソース情報 */}
+        {selectedSource && (
+          <div style={styles.sourcePreview}>
+            {selectedSource.thumbnail ? (
+              <img
+                src={selectedSource.thumbnail}
+                alt={selectedSource.name}
+                style={styles.previewThumbnail}
+              />
+            ) : (
+              <div style={styles.previewPlaceholder}>
+                {selectedSource.type === 'screen' ? '🖥️' : '🪟'}
+              </div>
+            )}
+            <div style={styles.previewInfo}>
+              <span style={styles.previewName}>{selectedSource.name}</span>
+              <span style={styles.previewType}>
+                {selectedSource.type === 'screen' ? '画面' : 'ウィンドウ'}
+              </span>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* URL表示 */}
+      <UrlDisplay streamInfo={streamInfo} />
+
+      {/* 注意書き */}
+      <div style={styles.notice}>
+        <span style={styles.noticeText}>
+          無料サーバーで運用中のため、遅延4秒以上・画質480pでの配信となります
+        </span>
+      </div>
+
+      {/* 停止/接続中ボタン */}
+      {isLoading && !isCapturing ? (
+        <button style={styles.connectingButton} disabled>
+          接続中...
+        </button>
+      ) : (
+        <button style={styles.stopButton} onClick={onStop}>
+          配信停止
+        </button>
+      )}
+    </div>
+  )
+}
+
+// Pebble（石ころ）カラーパレット
+const colors = {
+  bgSecondary: '#EDEAE5',
+  success: '#5D8A66',
+  successBg: '#E8F0EA',
+  error: '#C45C4A',
+  textPrimary: '#3D3D3D',
+  textMuted: '#9B9B9B',
+  white: '#FFFFFF',
+  border: '#E0DDD8',
+  stone: '#6B7280',
+  stoneLight: '#9CA3AF',
+}
+
+const styles: { [key: string]: React.CSSProperties } = {
+  streamingScreen: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '16px',
+    paddingTop: '32px',
+    flex: 1
+  },
+  statusCard: {
+    padding: '20px',
+    backgroundColor: colors.successBg,
+    borderRadius: '14px',
+    border: '1px solid rgba(93, 138, 102, 0.2)'
+  },
+  statusHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '10px'
+  },
+  statusDot: {
+    width: '10px',
+    height: '10px',
+    borderRadius: '50%',
+    boxShadow: '0 0 8px rgba(93, 138, 102, 0.5)'
+  },
+  statusText: {
+    fontSize: '15px',
+    fontWeight: 600,
+    color: colors.success
+  },
+  sourcePreview: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '12px',
+    marginTop: '14px',
+    padding: '12px',
+    backgroundColor: 'rgba(255, 255, 255, 0.8)',
+    borderRadius: '10px',
+    border: `1px solid ${colors.border}`
+  },
+  previewThumbnail: {
+    width: '100px',
+    height: '56px',
+    objectFit: 'cover',
+    borderRadius: '6px',
+    border: `1px solid ${colors.border}`
+  },
+  previewPlaceholder: {
+    width: '100px',
+    height: '56px',
+    backgroundColor: colors.bgSecondary,
+    borderRadius: '6px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    fontSize: '20px',
+    border: `1px solid ${colors.border}`
+  },
+  previewInfo: {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '4px',
+    minWidth: 0
+  },
+  previewName: {
+    fontSize: '13px',
+    color: colors.textPrimary,
+    fontWeight: 500,
+    wordBreak: 'break-word'
+  },
+  previewType: {
+    fontSize: '11px',
+    color: colors.textMuted
+  },
+  notice: {
+    padding: '10px 14px',
+    backgroundColor: colors.bgSecondary,
+    borderRadius: '10px',
+    border: `1px solid ${colors.border}`
+  },
+  noticeText: {
+    fontSize: '11px',
+    color: colors.textMuted,
+    lineHeight: 1.5
+  },
+  stopButton: {
+    padding: '16px 32px',
+    fontSize: '16px',
+    fontWeight: 600,
+    color: colors.white,
+    background: `linear-gradient(135deg, ${colors.error} 0%, #D4776A 100%)`,
+    border: 'none',
+    borderRadius: '14px',
+    cursor: 'pointer',
+    boxShadow: '0 4px 14px rgba(196, 92, 74, 0.35)',
+    transition: 'all 0.2s ease',
+    marginTop: 'auto'
+  },
+  connectingButton: {
+    padding: '16px 32px',
+    fontSize: '16px',
+    fontWeight: 600,
+    color: colors.white,
+    background: `linear-gradient(135deg, ${colors.stoneLight} 0%, ${colors.stone} 100%)`,
+    border: 'none',
+    borderRadius: '14px',
+    cursor: 'not-allowed',
+    marginTop: 'auto',
+    opacity: 0.7
+  }
+}

--- a/src/renderer/src/components/ObsStreamingScreen.tsx
+++ b/src/renderer/src/components/ObsStreamingScreen.tsx
@@ -1,0 +1,338 @@
+import { useState, useEffect, useCallback } from 'react'
+import type { StreamInfo, Platform } from '../../../shared/types'
+import { parseRtmpUrl } from '../utils/formatters'
+
+// スケルトンアニメーション用のスタイルを動的に追加
+const SKELETON_STYLE_ID = 'skeleton-animation-style'
+function injectSkeletonStyle() {
+  if (document.getElementById(SKELETON_STYLE_ID)) return
+  const style = document.createElement('style')
+  style.id = SKELETON_STYLE_ID
+  style.textContent = `
+    @keyframes skeleton-shimmer {
+      0% { background-position: 100% 0; }
+      100% { background-position: -100% 0; }
+    }
+    .skeleton-shimmer {
+      background: linear-gradient(
+        90deg,
+        #E0DDD8 0%,
+        #F7F6F3 50%,
+        #E0DDD8 100%
+      );
+      background-size: 200% 100%;
+      animation: skeleton-shimmer 1.5s ease-in-out infinite;
+    }
+  `
+  document.head.appendChild(style)
+}
+
+interface Props {
+  streamInfo: StreamInfo
+  onStop: () => void
+  isLoading: boolean
+  platform: Platform | null
+}
+
+export function ObsStreamingScreen({ streamInfo, onStop, isLoading, platform }: Props) {
+  const [copied, setCopied] = useState<string | null>(null)
+
+  useEffect(() => {
+    injectSkeletonStyle()
+  }, [])
+
+  const copyToClipboard = useCallback(async (text: string, key: string) => {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(key)
+      setTimeout(() => setCopied(null), 2000)
+    } catch {
+      // コピー失敗は無視
+    }
+  }, [])
+
+  const handleCopyServerUrl = useCallback(() => {
+    const parts = streamInfo.rtmpUrl ? parseRtmpUrl(streamInfo.rtmpUrl) : null
+    if (parts) copyToClipboard(parts.serverUrl, 'server')
+  }, [streamInfo.rtmpUrl, copyToClipboard])
+
+  const handleCopyStreamKey = useCallback(() => {
+    const parts = streamInfo.rtmpUrl ? parseRtmpUrl(streamInfo.rtmpUrl) : null
+    if (parts) copyToClipboard(parts.streamKey, 'key')
+  }, [streamInfo.rtmpUrl, copyToClipboard])
+
+  const handleCopyPublicUrl = useCallback(() => {
+    if (streamInfo.publicUrl) copyToClipboard(streamInfo.publicUrl, 'public')
+  }, [streamInfo.publicUrl, copyToClipboard])
+
+  const rtmpParts = streamInfo.rtmpUrl ? parseRtmpUrl(streamInfo.rtmpUrl) : null
+  const isStreamReady = streamInfo.readyForPlayback && streamInfo.publicUrl
+
+  return (
+    <div style={{
+      ...styles.streamingScreen,
+      paddingTop: platform === 'win32' ? '8px' : '32px'
+    }}>
+      {/* ステータス */}
+      <div style={styles.statusCard}>
+        <div style={styles.statusHeader}>
+          <span
+            style={{
+              ...styles.statusDot,
+              backgroundColor: isStreamReady ? '#4caf50' : '#ff9800'
+            }}
+          />
+          <span style={styles.statusText}>
+            {isStreamReady ? '配信中' : 'OBS接続待ち'}
+          </span>
+        </div>
+      </div>
+
+      {/* OBS設定情報（常に表示） */}
+      <div style={styles.obsSettingsCard}>
+        <h3 style={styles.cardTitle}>OBS設定</h3>
+        <p style={styles.obsDescription}>
+          OBSの「設定 &gt; 配信」で以下を入力し、「配信開始」を押してください
+        </p>
+
+        {rtmpParts ? (
+          <>
+            <div style={styles.section}>
+              <label style={styles.label}>サーバー:</label>
+              <div style={styles.urlRow}>
+                <code style={styles.url}>{rtmpParts.serverUrl}</code>
+                <button style={styles.copyButton} onClick={handleCopyServerUrl}>
+                  {copied === 'server' ? 'コピー済み' : 'コピー'}
+                </button>
+              </div>
+            </div>
+
+            <div style={styles.section}>
+              <label style={styles.label}>ストリームキー:</label>
+              <div style={styles.urlRow}>
+                <code style={styles.url}>{rtmpParts.streamKey}</code>
+                <button style={styles.copyButton} onClick={handleCopyStreamKey}>
+                  {copied === 'key' ? 'コピー済み' : 'コピー'}
+                </button>
+              </div>
+            </div>
+          </>
+        ) : (
+          <>
+            <div style={styles.section}>
+              <div style={styles.skeletonLabel} className="skeleton-shimmer" />
+              <div style={styles.skeletonUrl} className="skeleton-shimmer" />
+            </div>
+            <div style={styles.section}>
+              <div style={styles.skeletonLabel} className="skeleton-shimmer" />
+              <div style={styles.skeletonUrl} className="skeleton-shimmer" />
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* 公開URL */}
+      <div style={styles.publicUrlCard}>
+        <h3 style={styles.cardTitle}>公開URL</h3>
+        {isStreamReady ? (
+          <div style={styles.section}>
+            <label style={styles.label}>公開URL (iwaSync用):</label>
+            <div style={styles.urlRow}>
+              <code style={styles.url}>{streamInfo.publicUrl}</code>
+              <button style={styles.copyButton} onClick={handleCopyPublicUrl}>
+                {copied === 'public' ? 'コピー済み' : 'コピー'}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div style={styles.section}>
+            <div style={styles.skeletonLabel} className="skeleton-shimmer" />
+            <div style={styles.skeletonUrl} className="skeleton-shimmer" />
+          </div>
+        )}
+      </div>
+
+      {/* 注意書き */}
+      <div style={styles.notice}>
+        <span style={styles.noticeText}>
+          無料サーバーで運用中のため、遅延4秒以上・画質480pでの配信となります
+        </span>
+      </div>
+
+      {/* 停止ボタン */}
+      {isLoading ? (
+        <button style={styles.connectingButton} disabled>
+          接続中...
+        </button>
+      ) : (
+        <button style={styles.stopButton} onClick={onStop}>
+          配信停止
+        </button>
+      )}
+    </div>
+  )
+}
+
+// Pebble（石ころ）カラーパレット
+const colors = {
+  bgPrimary: '#F7F6F3',
+  bgSecondary: '#EDEAE5',
+  accent: '#8B7355',
+  accentLight: '#A89076',
+  success: '#5D8A66',
+  successBg: '#E8F0EA',
+  error: '#C45C4A',
+  textPrimary: '#3D3D3D',
+  textSecondary: '#6B6B6B',
+  textMuted: '#9B9B9B',
+  white: '#FFFFFF',
+  border: '#E0DDD8',
+  stone: '#6B7280',
+  stoneLight: '#9CA3AF',
+}
+
+const styles: { [key: string]: React.CSSProperties } = {
+  streamingScreen: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '16px',
+    paddingTop: '32px',
+    flex: 1
+  },
+  statusCard: {
+    padding: '20px',
+    backgroundColor: colors.successBg,
+    borderRadius: '14px',
+    border: '1px solid rgba(93, 138, 102, 0.2)'
+  },
+  statusHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '10px'
+  },
+  statusDot: {
+    width: '10px',
+    height: '10px',
+    borderRadius: '50%',
+    boxShadow: '0 0 8px rgba(93, 138, 102, 0.5)'
+  },
+  statusText: {
+    fontSize: '15px',
+    fontWeight: 600,
+    color: colors.success
+  },
+  obsSettingsCard: {
+    padding: '18px',
+    backgroundColor: colors.white,
+    borderRadius: '14px',
+    border: `1px solid ${colors.border}`,
+    boxShadow: '0 2px 8px rgba(0, 0, 0, 0.04)'
+  },
+  cardTitle: {
+    margin: '0 0 8px 0',
+    fontSize: '15px',
+    fontWeight: 600,
+    color: colors.textPrimary
+  },
+  obsDescription: {
+    margin: '0 0 14px 0',
+    fontSize: '12px',
+    color: colors.textSecondary,
+    lineHeight: 1.5
+  },
+  publicUrlCard: {
+    padding: '18px',
+    backgroundColor: colors.white,
+    borderRadius: '14px',
+    border: `1px solid ${colors.border}`,
+    boxShadow: '0 2px 8px rgba(0, 0, 0, 0.04)'
+  },
+  section: {
+    marginBottom: '14px'
+  },
+  label: {
+    fontSize: '11px',
+    fontWeight: 500,
+    color: colors.textSecondary,
+    display: 'block',
+    marginBottom: '6px',
+    textTransform: 'uppercase',
+    letterSpacing: '0.3px'
+  },
+  urlRow: {
+    display: 'flex',
+    gap: '10px',
+    alignItems: 'center'
+  },
+  url: {
+    flex: 1,
+    padding: '10px 12px',
+    backgroundColor: colors.bgPrimary,
+    borderRadius: '8px',
+    fontSize: '12px',
+    wordBreak: 'break-all',
+    fontFamily: 'SF Mono, Monaco, Consolas, monospace',
+    color: colors.textPrimary,
+    border: `1px solid ${colors.border}`
+  },
+  copyButton: {
+    padding: '10px 16px',
+    fontSize: '12px',
+    fontWeight: 600,
+    background: `linear-gradient(135deg, ${colors.accent} 0%, ${colors.accentLight} 100%)`,
+    color: colors.white,
+    border: 'none',
+    borderRadius: '8px',
+    cursor: 'pointer',
+    whiteSpace: 'nowrap',
+    boxShadow: '0 2px 8px rgba(139, 115, 85, 0.25)',
+    transition: 'all 0.2s ease'
+  },
+  notice: {
+    padding: '10px 14px',
+    backgroundColor: colors.bgSecondary,
+    borderRadius: '10px',
+    border: `1px solid ${colors.border}`
+  },
+  noticeText: {
+    fontSize: '11px',
+    color: colors.textMuted,
+    lineHeight: 1.5
+  },
+  stopButton: {
+    padding: '16px 32px',
+    fontSize: '16px',
+    fontWeight: 600,
+    color: colors.white,
+    background: `linear-gradient(135deg, ${colors.error} 0%, #D4776A 100%)`,
+    border: 'none',
+    borderRadius: '14px',
+    cursor: 'pointer',
+    boxShadow: '0 4px 14px rgba(196, 92, 74, 0.35)',
+    transition: 'all 0.2s ease',
+    marginTop: 'auto'
+  },
+  connectingButton: {
+    padding: '16px 32px',
+    fontSize: '16px',
+    fontWeight: 600,
+    color: colors.white,
+    background: `linear-gradient(135deg, ${colors.stoneLight} 0%, ${colors.stone} 100%)`,
+    border: 'none',
+    borderRadius: '14px',
+    cursor: 'not-allowed',
+    marginTop: 'auto',
+    opacity: 0.7
+  },
+  skeletonLabel: {
+    width: '100px',
+    height: '12px',
+    borderRadius: '4px',
+    marginBottom: '8px'
+  },
+  skeletonUrl: {
+    width: '100%',
+    height: '40px',
+    borderRadius: '8px'
+  }
+}

--- a/src/renderer/src/utils/__tests__/formatters.test.ts
+++ b/src/renderer/src/utils/__tests__/formatters.test.ts
@@ -6,7 +6,8 @@ import {
   getStreamStatusText,
   getStreamStatusColor,
   getConnectionStateText,
-  getStreamButtonText
+  getStreamButtonText,
+  parseRtmpUrl
 } from '../formatters'
 
 describe('validateStreamId', () => {
@@ -184,5 +185,31 @@ describe('getStreamButtonText', () => {
 
   it('isLoading=false, isStreaming=false は 配信開始 を返す', () => {
     expect(getStreamButtonText(false, false)).toBe('配信開始')
+  })
+})
+
+describe('parseRtmpUrl', () => {
+  it('標準的なRTMP URLをサーバーURLとストリームキーに分割する', () => {
+    const result = parseRtmpUrl('rtmp://pebble.xrift.net:1935/mystream')
+    expect(result).toEqual({
+      serverUrl: 'rtmp://pebble.xrift.net:1935',
+      streamKey: 'mystream'
+    })
+  })
+
+  it('ストリームキーにハイフンを含むURLを分割する', () => {
+    const result = parseRtmpUrl('rtmp://pebble.xrift.net:1935/a1b2c3d4')
+    expect(result).toEqual({
+      serverUrl: 'rtmp://pebble.xrift.net:1935',
+      streamKey: 'a1b2c3d4'
+    })
+  })
+
+  it('スラッシュが無いURLはnullを返す', () => {
+    expect(parseRtmpUrl('invalid')).toBeNull()
+  })
+
+  it('末尾がスラッシュのURLはnullを返す', () => {
+    expect(parseRtmpUrl('rtmp://pebble.xrift.net:1935/')).toBeNull()
   })
 })

--- a/src/renderer/src/utils/formatters.ts
+++ b/src/renderer/src/utils/formatters.ts
@@ -105,3 +105,22 @@ export function getStreamButtonText(isLoading: boolean, isStreaming: boolean): s
   }
   return isStreaming ? '配信停止' : '配信開始'
 }
+
+// RTMP URL分割結果
+export interface RtmpUrlParts {
+  serverUrl: string
+  streamKey: string
+}
+
+// RTMP URLをサーバーURLとストリームキーに分割する
+// 例: "rtmp://pebble.xrift.net:1935/mystream" → { serverUrl: "rtmp://pebble.xrift.net:1935", streamKey: "mystream" }
+export function parseRtmpUrl(rtmpUrl: string): RtmpUrlParts | null {
+  const lastSlash = rtmpUrl.lastIndexOf('/')
+  if (lastSlash <= 0) return null
+
+  const serverUrl = rtmpUrl.substring(0, lastSlash)
+  const streamKey = rtmpUrl.substring(lastSlash + 1)
+  if (!serverUrl || !streamKey) return null
+
+  return { serverUrl, streamKey }
+}


### PR DESCRIPTION
## Summary
- OBSモードで「OBS接続待ち」のままRTMP URL/ストリームキーが表示されない問題を修正
- 配信中画面を `ObsStreamingScreen` と `DirectStreamingScreen` に分離し、各モードに最適化
- OBS画面ではRTMP設定情報（サーバーURL・ストリームキー）を常に表示し、OBSの設定手順を案内

## Test plan
- [x] `npm run typecheck` パス
- [x] `npm run test` 128件パス（parseRtmpUrl テスト4件追加）
- [ ] OBSモードで配信開始 → RTMP URL/ストリームキーが即座に表示されること
- [ ] 直接配信モードの動作が従来通りであること

🤖 Generated with [Claude Code](https://claude.com/claude-code)