### PR TITLE
pack-boothをdmg/exeインストーラーのzip化に変更

### DIFF
--- a/scripts/pack-booth.mjs
+++ b/scripts/pack-booth.mjs
@@ -1,5 +1,5 @@
 /**
- * Booth アップロード用に dist/ のビルド済みディレクトリを zip に圧縮するスクリプト
+ * Booth アップロード用に dist/ のインストーラーを zip に圧縮するスクリプト
  * 使い方: npm run pack:booth
  */
 import { readFileSync, mkdirSync, existsSync, rmSync } from 'node:fs'
@@ -13,11 +13,11 @@ const pkg = JSON.parse(readFileSync(join(rootDir, 'package.json'), 'utf-8'))
 const version = pkg.version
 const name = pkg.productName || 'PebbleChat'
 
-// zip にするターゲット: [ディレクトリ名, 出力ファイル名]
+// zip にするターゲット: [元ファイル名, 出力 zip 名]
 const targets = [
-  ['mac-arm64', `${name}-${version}-mac-arm64.zip`],
-  ['mac', `${name}-${version}-mac-x64.zip`],
-  ['win-unpacked', `${name}-${version}-win-x64.zip`],
+  [`${name}-${version}-arm64.dmg`, `${name}-${version}-mac-arm64.zip`],
+  [`${name}-${version}.dmg`, `${name}-${version}-mac-x64.zip`],
+  [`${name} Setup ${version}.exe`, `${name}-${version}-win-x64.zip`],
 ]
 
 if (!existsSync(distDir)) {
@@ -34,21 +34,21 @@ mkdirSync(boothDir, { recursive: true })
 console.log(`\nBooth 用 zip を作成します (v${version})\n`)
 
 let count = 0
-for (const [dir, zipName] of targets) {
-  const srcDir = join(distDir, dir)
-  if (!existsSync(srcDir)) {
-    console.log(`  [skip] ${dir}/ が見つかりません`)
+for (const [srcFile, zipName] of targets) {
+  const srcPath = join(distDir, srcFile)
+  if (!existsSync(srcPath)) {
+    console.log(`  [skip] ${srcFile} が見つかりません`)
     continue
   }
 
   const zipPath = join(boothDir, zipName)
-  execSync(`cd "${srcDir}" && zip -r -q "${zipPath}" .`)
+  execSync(`cd "${distDir}" && zip -j -q "${zipPath}" "${srcFile}"`)
   console.log(`  -> ${zipName}`)
   count++
 }
 
 if (count === 0) {
-  console.error('\nzip にできるディレクトリが見つかりませんでした。ビルドを実行してください。')
+  console.error('\nzip にできるファイルが見つかりませんでした。ビルドを実行してください。')
   process.exit(1)
 }
 


### PR DESCRIPTION
## Summary
- `pack-booth.mjs` が `.app` / `win-unpacked` ディレクトリを zip にしていたのを修正
- dmg (Mac) と exe インストーラー (Windows) を zip に入れる方式に変更

## Test plan
- [x] `node scripts/pack-booth.mjs` で dmg/exe が正しく zip 化されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)