### PR TITLE
fix: MediaMTX stderrの個別Sentry送信をやめてbreadcrumb方式に変更

### DIFF
--- a/src/main/services/mediamtx.ts
+++ b/src/main/services/mediamtx.ts
@@ -8,6 +8,10 @@ import { updateMediaMTXConfig } from './binary'
 
 let mediamtxProcess: ChildProcess | null = null
 
+// stopMediaMTX による意図的な停止かどうかのフラグ
+// 異常終了（クラッシュ）のときだけSentryへ送るために使う
+let stoppingIntentionally = false
+
 // 既存のMediaMTXプロセスを強制終了（Windows用）
 function killExistingMediaMTX(): void {
   if (process.platform === 'win32') {
@@ -88,8 +92,15 @@ export async function startMediaMTX(streamId?: string): Promise<MediaMTXStatus> 
         if (isIgnorableStderrMessage(line) || isFFmpegInfoMessage(line)) {
           console.log('[MediaMTX]', line.trim())
         } else {
+          // 個別行をエラーとして送らず、breadcrumbとして蓄積する。
+          // 実際にプロセスが異常終了したとき（close handler）にだけ、
+          // 直近のstderrを文脈として付けた1イベントを送る。
           console.error('[MediaMTX Error]', line)
-          Sentry.captureMessage(`MediaMTX stderr: ${line.trim()}`, 'error')
+          Sentry.addBreadcrumb({
+            category: 'mediamtx.stderr',
+            level: 'error',
+            message: line.trim()
+          })
           startupError = line
         }
       }
@@ -103,13 +114,29 @@ export async function startMediaMTX(streamId?: string): Promise<MediaMTXStatus> 
           console.log('[MediaMTX]', stderrBuffer.trim())
         } else {
           console.error('[MediaMTX Error]', stderrBuffer)
-          Sentry.captureMessage(`MediaMTX stderr: ${stderrBuffer.trim()}`, 'error')
+          Sentry.addBreadcrumb({
+            category: 'mediamtx.stderr',
+            level: 'error',
+            message: stderrBuffer.trim()
+          })
           startupError = stderrBuffer
         }
         stderrBuffer = ''
       }
 
       console.log(`[MediaMTX] Process exited with code ${code}`)
+
+      // 意図的な停止ではない異常終了（クラッシュ）のときだけSentryへ送る。
+      // 直近のstderrはbreadcrumbとして自動的にイベントへ付与される。
+      if (code !== 0 && code !== null && !stoppingIntentionally) {
+        Sentry.captureException(
+          new Error(
+            `MediaMTX exited unexpectedly with code ${code}` +
+              (startupError ? `: ${startupError.trim()}` : '')
+          )
+        )
+      }
+      stoppingIntentionally = false
       mediamtxProcess = null
 
       if (!started) {
@@ -159,6 +186,9 @@ export async function stopMediaMTX(): Promise<void> {
   if (!mediamtxProcess) {
     return
   }
+
+  // 意図的な停止なので、close handler でのクラッシュ送信を抑止する
+  stoppingIntentionally = true
 
   return new Promise((resolve) => {
     mediamtxProcess!.on('close', () => {


### PR DESCRIPTION
## 背景

PebbleChat から Sentry へのエラーが多すぎる、という問題への対応。

原因は `src/main/services/mediamtx.ts` で **MediaMTX/FFmpeg の stderr 出力を1行ごとに `Sentry.captureMessage(..., 'error')` で送っていた** こと。

- FFmpeg/MediaMTX は正常時でも膨大かつ多様な stderr を吐く
- 「ホワイトリスト（`isFFmpegInfoMessage` / `isIgnorableStderrMessage`）に無い行は全部エラー」という方式のため、未登録パターンが出るたびに大量送信される
- git ログ上も `Stream mapping / Side data / Lavf パターンを追加` 等、新しいメッセージが出るたびにフィルタを追記するモグラ叩き状態になっていた（＝原理的に追いつかない）
- 行バッファリングの断片（`Lavc59`、`tbn` 等）まで個別イベント化されノイズに

## 変更内容

「正常出力を除外する」発想を捨て、**breadcrumb 方式**に変更：

- stderr のエラー候補行は `Sentry.addBreadcrumb` で蓄積するだけにする
- **プロセスが意図せず異常終了した時だけ**（exit code が 0/null 以外）、直近の stderr を文脈に付けた `captureException` を1イベント送る
- `stopMediaMTX` による意図的な停止は `stoppingIntentionally` フラグで除外

これによりクラッシュ1回につき1イベント＋直近stderr文脈付き、になりノイズが激減する。

## 影響範囲

- 配信失敗の原因は、クラッシュ時に breadcrumb として引き続き Sentry から追える
- `pollHlsPlaybackReady` の HLS タイムアウト `captureMessage('warning')` は低頻度かつ有用なため据え置き

## テスト

- `npm run test`（stderr/mediamtx/ffmpeg の純粋関数テスト 96 件）パス
- `npm run lint` / `npm run typecheck`：本変更による新規エラーなし（既存の警告・テストファイルのエラーのみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)