### PR TITLE
chore: バージョンを 0.2.12 に更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pebble-chat",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "VRChat向けの簡単配信アプリ - PebbleChat",
   "main": "./out/main/index.js",
   "author": "WebXR-JP",


### PR DESCRIPTION
## 概要

MediaMTX stderr の Sentry 送信を breadcrumb 方式に変更した修正（#49）をリリースするためのバージョンバンプ。

`0.2.11` → `0.2.12`（patch）

## 含まれる変更
- #49 MediaMTX stderrの個別Sentry送信をやめてbreadcrumb方式に変更

## リリース手順
このPRをマージ後、main に `v0.2.12` タグを打つと `build-and-deploy` が走り、mac/win ビルド → R2 配信 → `version.json` 更新（自動アップデート判定用）まで実行される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)